### PR TITLE
Add Player/Kill Count UI

### DIFF
--- a/Content/ImitationTrigger/Blueprints/UI/PlayerKillCount/KillImage.uasset
+++ b/Content/ImitationTrigger/Blueprints/UI/PlayerKillCount/KillImage.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e84fc225bf979c599bca7002811c912100c3c633f673c272ae2254b27ff58f1a
+size 76321

--- a/Content/ImitationTrigger/Blueprints/UI/PlayerKillCount/Player.uasset
+++ b/Content/ImitationTrigger/Blueprints/UI/PlayerKillCount/Player.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9e41a5e32716fa325b05cc07b942bf16920ec621762ffb3b0ce3a8a57f7772fc
+size 73829

--- a/Content/ImitationTrigger/Blueprints/UI/PlayerKillCount/WBP_PlayerKillCount.uasset
+++ b/Content/ImitationTrigger/Blueprints/UI/PlayerKillCount/WBP_PlayerKillCount.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b4ad84233fa1df8fe962960e9026eec54366b7d7d8fee8ca3461302f7ac63c8c
+size 36994

--- a/Source/ImitationTrigger/UI/PlayerKillCount/PlayerKillCount.cpp
+++ b/Source/ImitationTrigger/UI/PlayerKillCount/PlayerKillCount.cpp
@@ -1,0 +1,24 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+
+#include "UI/PlayerKillCount/PlayerKillCount.h"
+
+#include "Components/TextBlock.h"
+
+void UPlayerKillCount::UpdateRemainingPlayer(int32 RemainingPlayerCount)
+{
+	if (RemainingPlayerCountBlock)
+	{
+		FText PlayerCount = FText::AsNumber(RemainingPlayerCount);
+		RemainingPlayerCountBlock->SetText(PlayerCount);
+	}
+}
+
+void UPlayerKillCount::UpdatePlayerKillCount(int32 PlayerKillCount)
+{
+	if (PlayerKillCountBlock)
+	{
+		FText KillCount = FText::AsNumber(PlayerKillCount);
+		PlayerKillCountBlock->SetText(KillCount);
+	}
+}

--- a/Source/ImitationTrigger/UI/PlayerKillCount/PlayerKillCount.h
+++ b/Source/ImitationTrigger/UI/PlayerKillCount/PlayerKillCount.h
@@ -1,0 +1,33 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Blueprint/UserWidget.h"
+#include "PlayerKillCount.generated.h"
+
+class UTextBlock;
+/**
+ * 
+ */
+UCLASS()
+class IMITATIONTRIGGER_API UPlayerKillCount : public UUserWidget
+{
+	GENERATED_BODY()
+
+public:
+	UFUNCTION(BlueprintCallable, Category = "UI")
+	void UpdateRemainingPlayer(int32 RemainingPlayerCount);
+
+	UFUNCTION(BlueprintCallable, Category = "UI")
+	void UpdatePlayerKillCount(int32 PlayerKillCount);
+
+protected:
+
+	UPROPERTY(meta = (BindWidget))
+	UTextBlock* RemainingPlayerCountBlock;
+
+	UPROPERTY(meta = (BindWidget))
+	UTextBlock* PlayerKillCountBlock;
+	
+};


### PR DESCRIPTION
<!--
[Pull Reqeust 템플릿]
이 메시지는 '주석'이므로, 실제 문서에는 포함되지 않습니다.
PR을 작성하기 전, 아래 내용을 점검해주세요.

1. 문제없이 빌드가 되는 코드인가?
2. 내가 구현한 내용에 문제는 없는가?
3. Code Convention과 Unreal Project Convention을 잘 지켰는가?
4. branch의 이름을 올바르게 지었는가? (Unreal Project Convention 참고) 
-->

### 변경 사항 요약
<!-- 이 PR에서 어떤 변경이 있었는지 요약해주세요 -->
- WBP_PlayerKillCount 추가 및 관련 이미지 2개 추가
- PlayerKillCount cpp/h 추가


### 테스트 방법
<!-- 구현한 내용을 어떻게 확인할 수 있는지, 어떻게 테스트할 수 있는지 설명하세요 -->
1. 현재는 실제로 적용해놓지않았고 이후 PR이 완료되면 HUD에 융합하는 작업을 할것임.

### 스크린샷 (선택사항)
<!-- 변경 사항을 보여줄 스크린샷을 첨부해주세요 -->
<!-- 스크린샷이 없다면 이 부분을 지워주세요. -->
<img width="365" height="130" alt="image" src="https://github.com/user-attachments/assets/810ec32b-3582-42c0-9fb1-c2ec438ef3a3" />


### 기타 사항
<!-- 리뷰어에게 전달하고 싶은 메시지나 참고할 만한 내용을 적어주세요 -->
번외 이야기긴하지만. 기능상 회복아이템을 꾹 눌럿을때 일반적으로 사용되는 원형의 선택관련 UI도 적용이 가능하긴 합니다. ( 여자처자 찾아보니 기능을 구할수있었습니다.) 실제로 구현하는데는 제 생각으로는 몇시간 테스트가 필요하긴하겠지만
그래서 그냥 무기슬롯 1,2와 3,4,5 키로 각각 체력 아이템 소,중,대 이렇게할까.. 아직 고민중인 단계입니다.


<!--
[Pull Reqeust 템플릿]
이 메시지는 '주석'이므로, 실제 문서에는 포함되지 않습니다.
PR을 제출하기 전, 아래 내용을 점검해주세요.

1. 올바른 리뷰어를 지정했는가?
2. 템플릿 안에 있는 불필요한 주석을 제거하고, 내용을 채웠는가? 
   템플릿 맨 위에 있는 주석과 맨 아래에 있는 지우지 않아도 됩니다.
-->

---
🙏 리뷰 감사합니다!